### PR TITLE
Prioritize contiguity of matches

### DIFF
--- a/src/match.h
+++ b/src/match.h
@@ -82,7 +82,7 @@ struct Scorer {
         (std::uint64_t(prefix_score) << 31) +
         (std::uint64_t(std::numeric_limits<CharCount>::max() - word_prefix_len)
          << 28) +
-        (std::uint64_t(parts) << 20) +
+        (std::uint64_t(parts) << 56) +
         (std::uint64_t(std::numeric_limits<CharCount>::max() -
                        cur_file_prefix_len)
          << 14) +


### PR DESCRIPTION
I don't really expect this to get merged, as I haven't tested it thoroughly or put much thought into how this affects the scoring algorithm in other ways. Consider it more a proof-of-concept for #18 - `scorer.parts` now counts the total number of contiguous chunks matched (I think) instead of just the number of path components, and that value is heavily prioritized in scoring.