### PR TITLE
Correct append of -std to CXX flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 include_directories(${PROJECT_SOURCE_DIR}/src)
 set(CMAKE_BUILD_TYPE Release)
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU|Clang|Intel")
-  list(APPEND CMAKE_CXX_FLAGS "-std=c++11 -Wall")
+    add_compile_options(-std=c++0x)
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
   # Versions of MSVC that support C++11 at all support it by default, so hope
   # for the best...


### PR DESCRIPTION
The previous approach, in the presence of existing CXX flags, resulted
in a broken CMAKE_CXX_FLAGS value with a `;` in the middle. The
canonical way of adding a compile option is to use the cmake function
`add_compile_options`, which is available from 2.8.12 onwards.

If you need something compatible with cmake 2.8.11 and prior, you can
use `add_definitions(-std=c++0x)` instead.