### PR TITLE
Install cpsm_py.so once

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,6 @@ if(APPLE)
   set_target_properties(cpsm_py PROPERTIES SUFFIX ".so")
 endif()
 install(TARGETS cpsm_py DESTINATION ${PROJECT_SOURCE_DIR}/autoload)
-install(TARGETS cpsm_py DESTINATION ${PROJECT_SOURCE_DIR}/bin)
 
 add_executable(cpsm_cli src/cpsm_cli_main.cc)
 target_link_libraries(cpsm_cli cpsm_core ${Boost_PROGRAM_OPTIONS_LIBRARIES})


### PR DESCRIPTION
Currently `cpsm_py.so` is installed twice:
```
-- Installing: autoload/cpsm_py.so
-- Installing: bin/cpsm_py.so
```
This PR omits the unnecessary installation into `bin/`.