### PR TITLE
Add the missing header

### DIFF
--- a/src/matcher.h
+++ b/src/matcher.h
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <functional>
 #include <iterator>
+#include <limits>
 #include <string>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
This PR fixes the following error.

```bash
/home/r6eve/.vim/plugged/cpsm/src/matcher.h:636:17: error: ‘numeric_limits’ is not a member of ‘std’
  636 |     return std::numeric_limits<T>::max() - x;
      |                 ^~~~~~~~~~~~~~
```