### PR TITLE
Support highlight for CtrlP with devicons

### DIFF
--- a/src/ctrlp_util.cc
+++ b/src/ctrlp_util.cc
@@ -111,6 +111,8 @@ void get_highlight_regexes(boost::string_ref const mode,
     for (char const c : line_prefix) {
       write_char(c);
     }
+    // support highlight for CtrlP with devicons
+    regex += R"(\%\(\.\+\s\+\)\?)";
     std::size_t i = 0;
     for (; i < group.first; i++) {
       write_char(item[i]);


### PR DESCRIPTION
Hi,

When I use CtrlP with devicons, cpsm's regex highlight does not work. Tried to add regex to support both cases with and without Devicons at beginging of each line. 

Here is my test case:

<img width="745" alt="image" src="https://github.com/nixprime/cpsm/assets/438791/d4f2c1f0-583e-4a37-95b7-572383d3653d">

```vim
>  zero/nvim/plugins/ctrlp.lua
> zero/nvim/plugins/ctrlp.lua
>  zero/vim/plugins/ctrlp.vim
```

```vim
call matchadd('CtrlPMatch', '\V\C\^> \%\(\.\+\s\+\)\?zero/nvim/plugins/\zsctrlp\ze.lua\$')
```

I think this will make matching slow down a bit. Please merge it if you think it does make senses, thanks.