### PR TITLE
Set cmake_minimum_required to 3.5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5.0)
 
 project(cpsm)
 option(PY3 "Build for python3 instead of python2." OFF)


### PR DESCRIPTION
Dear maintainers,

When compiling `cpsm` on macOS with `cmake` version 4.2.0, I got this error:

```shell
$ env PY3=ON ./install.sh
Python 3 selected by PY3=ON
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.

-- Configuring incomplete, errors occurred!
```

I follow suggestions from error, I changed `cmake_minimum_required` to `3.5.0`, it complies successfully! But this means `cpsm` will now requires version 3.5 or upper.

Please help merge this PR if it does make senses or let me know if I need to update something.

Thanks.


